### PR TITLE
Add Docker support for generating shorts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+.env.*
+*.swp
+.DS_Store
+gameplay
+generated
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.10-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set workdir
+WORKDIR /app
+
+# Install python dependencies
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Default command
+CMD ["python", "shorts.py"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ installation instructions.
 Environment variables from a `.env` file will be loaded automatically if
 present.
 
+## Docker
+
+Build and run using Docker:
+
+```bash
+docker build -t shorts-maker .
+docker run --rm \
+    -v $(pwd)/gameplay:/app/gameplay \
+    -v $(pwd)/generated:/app/generated \
+    --env-file .env \
+    shorts-maker
+```
+
 ## Running Tests
 
 Unit tests live in the `tests/` folder. Run them with:


### PR DESCRIPTION
## Summary
- add Dockerfile with Python, ffmpeg, and project dependencies
- document Docker usage and add .dockerignore

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c9fcc7c483329d190ac039802e70