### PR TITLE
Add optional GPU rendering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ installation instructions.
 
 3. Generated clips are written to the `generated/` directory.
 
+Pass the optional `--use-gpu` flag to enable rendering via FFmpeg's
+`h264_nvenc` encoder. This requires an NVIDIA GPU and an FFmpeg build with
+NVENC support. The script will raise an error if GPU encoding is requested but
+not available.
+
 Environment variables from a `.env` file will be loaded automatically if
 present.
 


### PR DESCRIPTION
## Summary
- add a `--use-gpu` CLI flag that toggles NVENC rendering through the processing configuration
- update the rendering routine to select the GPU codec, reuse retry logic, and surface errors after the final attempt
- document GPU usage and extend the test suite to cover GPU encoding and retry failures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c94438fe3c833280bb514d65e9828a